### PR TITLE
Fix image paths

### DIFF
--- a/angelsenvy.html
+++ b/angelsenvy.html
@@ -158,7 +158,7 @@
             src='https://api.mapbox.com/styles/v1/gisdataqueen/ckqfuhre73t8n17s1s1sjbiyv.html?fresh=true&title=false&access_token=pk.eyJ1IjoiZ2lzZGF0YXF1ZWVuIiwiYSI6ImNrcHUzMDN4MjBhcnMycHJyN2FlN2RibjQifQ.-VUA-F2cuiMTy-VpzwJblQ'></iframe>
 
     <div class="column">
-        <img class="max-image-width" src="..\images\angels-envy.jpeg" title="Angel's Envy">
+        <img class="max-image-width" src="../Images/angels-envy.jpeg" title="Angel's Envy">
         <p>Angel's Envy Distillery
             <br>
             <a href="https://www.angelsenvy.com" class="linkbox">Photograph: Angel's Envy Distillery</a>

--- a/evanwilliams.html
+++ b/evanwilliams.html
@@ -159,7 +159,7 @@
             src='https://api.mapbox.com/styles/v1/gisdataqueen/ckqfuhre73t8n17s1s1sjbiyv.html?fresh=true&title=false&access_token=pk.eyJ1IjoiZ2lzZGF0YXF1ZWVuIiwiYSI6ImNrcHUzMDN4MjBhcnMycHJyN2FlN2RibjQifQ.-VUA-F2cuiMTy-VpzwJblQ'></iframe>
 
     <div class="column">
-        <img class="max-image-width" src="..\images\evanwilliams.jpeg" title="Evan Williams Distillery">
+        <img class="max-image-width" src="../Images/evanwilliams.jpeg" title="Evan Williams Distillery">
         <p>Evan Williams Distillery
             <br>
             <a href="https://www.angelsenvy.com" class="linkbox">Photograph: Evan Williams Distillery</a>

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
 
             </div>
             <div class="column">
-                <img class="max-image-width" src="..\images\kbt-logo-500-e1515037784706.png"
+                <img class="max-image-width" src="../Images/kbt-logo-500-e1515037784706.png"
                     title="Bourbon Trail Logo">
                 <div class="linkbox"><a href="https://kybourbontrail.com/">Kentucky Bourbon Trail Official Website</a></div>
                 <br>
@@ -212,7 +212,7 @@
                         <li><a href="woodfordreserve.html" target="_blank">Woodford Reserve Distillery near Versailles</a></li>
                     </ul>
                 </p>
-                <img class="max-image-width" src="..\images\passport.png"
+                <img class="max-image-width" src="../Images/passport.png"
                 title="Bourbon Trail Passport">
                 <div class="linkbox"><a href="https://kybourbontrail.com/field-guide/">Plan your trip today!</a></div>
             </div>

--- a/townbranch.html
+++ b/townbranch.html
@@ -157,7 +157,7 @@
             src='https://api.mapbox.com/styles/v1/gisdataqueen/ckqehfvjh2gbc17qkjbedlyag.html?fresh=true&title=false&access_token=pk.eyJ1IjoiZ2lzZGF0YXF1ZWVuIiwiYSI6ImNrcHUzMDN4MjBhcnMycHJyN2FlN2RibjQifQ.-VUA-F2cuiMTy-VpzwJblQ'></iframe>
 
     <div class="column">
-        <img class="max-image-width" src="..\images\TownBranchStills.jpeg" title="Town Branch Stills">
+        <img class="max-image-width" src="../Images/TownBranchStills.jpeg" title="Town Branch Stills">
         <p>Town Branch Still Pots
             <br>
             <a href="https://www.lexingtonbrewingco.com" class="linkbox">Photograph: Town Branch Distillery</a>

--- a/woodfordreserve.html
+++ b/woodfordreserve.html
@@ -160,7 +160,7 @@
             src='https://api.mapbox.com/styles/v1/gisdataqueen/ckqehfvjh2gbc17qkjbedlyag.html?fresh=true&title=false&access_token=pk.eyJ1IjoiZ2lzZGF0YXF1ZWVuIiwiYSI6ImNrcHUzMDN4MjBhcnMycHJyN2FlN2RibjQifQ.-VUA-F2cuiMTy-VpzwJblQ'></iframe>
 
     <div class="column">
-        <img class="max-image-width" src="..\images\woodfordreserve.jpeg" title="Woodford Reserve Distillery">
+        <img class="max-image-width" src="../Images/woodfordreserve.jpeg" title="Woodford Reserve Distillery">
         <p>Town Branch Still Pots
             <br>
             <a href="https://www.woodfordreserve.com" class="linkbox">Photograph: Woodford Reserve Distillery</a>


### PR DESCRIPTION
Images on your web pages were not appearing because the directory where they reside was called `Images`, but referenced as `images` in your file paths. I also switched the slashes in the paths from backslashes to forward slashes. File paths references using backslashes can sometimes throw unexpected errors. 